### PR TITLE
Don't assume directory doesn't exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Usage
 
 Example usage:
 
-    $ heroku config:add BUILDPACK_URL=https://github.com/odedlaz/heroku-buildpack-awscli.git
+    $ heroku buildpacks:add https://github.com/Shopiy/heroku-buildpack-awscli.git
 
     $ heroku config:add AWS_ACCESS_KEY_ID=<aws-access-key>
 

--- a/bin/compile
+++ b/bin/compile
@@ -24,7 +24,7 @@ echo "-----> Fetching AWS CLI into slug"
 curl --progress-bar -o /tmp/awscli-bundle.zip $AWS_CLI_URL
 unzip -qq -d "$BUILD_DIR/vendor" /tmp/awscli-bundle.zip
 
-echo "-----> adding installer script into app/.profile.d"
+echo "-----> Adding installer script into app/.profile.d"
 mkdir -p $BUILD_DIR/.profile.d
 cp "$BUILDPACK_DIR/bin/install_awscli.sh" $BUILD_DIR/.profile.d/
 chmod +x $BUILD_DIR/.profile.d/install_awscli.sh
@@ -32,4 +32,4 @@ chmod +x $BUILD_DIR/.profile.d/install_awscli.sh
 #cleaning up...
 rm -rf /tmp/awscli*
 
-echo "-----> aws cli installation done"
+echo "-----> AWS CLI installation done"

--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -4,6 +4,8 @@ chmod +x /app/vendor/awscli-bundle/install
 /app/vendor/awscli-bundle/install -i $INSTALL_DIR
 chmod u+x $INSTALL_DIR/bin/aws
 
+export PATH=~/vendor/awscli/bin:$PATH
+
 mkdir ~/.aws
 
 cat >> ~/.aws/credentials << EOF
@@ -12,7 +14,7 @@ aws_access_key_id = $AWS_KEY
 aws_secret_access_key = $AWS_SECRET_KEY
 EOF
 
-cat >> ~/.aws/config << EOF 
+cat >> ~/.aws/config << EOF
 [default]
 region = $AWS_REGION
 EOF

--- a/bin/install_awscli.sh
+++ b/bin/install_awscli.sh
@@ -6,7 +6,7 @@ chmod u+x $INSTALL_DIR/bin/aws
 
 export PATH=~/vendor/awscli/bin:$PATH
 
-mkdir ~/.aws
+mkdir -p ~/.aws
 
 cat >> ~/.aws/credentials << EOF
 [default]


### PR DESCRIPTION
`/exec rails c` breaks in GCP kubeshell due to this shell script trying to make a directory that already exists.

Let's fix that